### PR TITLE
French typographic rules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,16 @@ change any ampersand which has already been wrapped in this fashion.
 Wraps multiple capital letters in ``<span class="caps">`` so they can
 be styled with CSS.
 
+``french insecable``
+--------------------
+
+Replace space by thin non breakable space in the following cases :
+
+* between a word and double punctuation sign (colomn, semi colomn)
+* between french quotes and the text inside them
+* between digits
+
+The locale must be set to fr_FR for being applied
 
 ``initial_quotes``
 ------------------


### PR DESCRIPTION
The french typographic require narrow non breakable space in some special cases : 

between a word and double punctuation point ( : ; ? ! )
inside quoted text : « »
or as separator between numbers (phone number…)

This is done with a "nowrap" attribute, inside a span element (as for amp transformation), you can get more information about nnbsp in html in stackoverfow.

I'm aware that this is specific to french, so the processor is only activated when locale is fr_FR, some other specific language can be added, but I don't know the rules for each of them and let the community add them if need. The locale can be overrided in the locale module.

The doctests are Ok, and I updated the doc, as long as my english is correct.

stackoverfow : http://stackoverflow.com/questions/595365/how-to-render-narrow-non-breaking-spaces-in-html-for-windows
locale : http://docs.python.org/2/library/locale.html
