### PR TITLE
Update `smartypants()` to use `smartypants.smartypants` instead of `smar...

### DIFF
--- a/typogrify/filters.py
+++ b/typogrify/filters.py
@@ -170,7 +170,7 @@ def smartypants(text):
     except ImportError:
         raise TypogrifyError("Error in {% smartypants %} filter: The Python smartypants library isn't installed.")
     else:
-        output = smartypants.smartyPants(text)
+        output = smartypants.smartypants(text)
         return output
 
 


### PR DESCRIPTION
...typants.smartyPants`

`smartyPants()` will be removed in v2.0.0, `smartypants()` should be used instead.

("Woah, wait, that's a lot of Haggar pantses. I mean, how much is Haggar paying us?")
