### PR TITLE
Don't add caps markup inside <title> tag

### DIFF
--- a/typogrify/filters.py
+++ b/typogrify/filters.py
@@ -104,7 +104,7 @@ def caps(text):
                 tail = ''
             return """<span class="caps">%s</span>%s""" % (caps, tail)
 
-    tags_to_skip_regex = re.compile("<(/)?(?:pre|code|kbd|script|math)[^>]*>", re.IGNORECASE)
+    tags_to_skip_regex = re.compile("<(/)?(?:pre|code|kbd|script|math|title)[^>]*>", re.IGNORECASE)
 
     for token in tokens:
         if token[0] == "tag":


### PR DESCRIPTION
I am using typogrify as a filter for HTML files and if there is a ALL CAPS title, it displays wrong.
