### PR TITLE
Ignore text based on user-specified regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,20 @@ The filters can be used in any environment by importing them from
     from typogrify.filters import typogrify
     content = typogrify(content)
 
+All content within ``<pre>`` and ``<code>`` tags will not be
+processed by default. There is an optional second argument that 
+lets one incorporate additional tags whose content will be
+ignored. Assuming in addition to ``<pre>`` and ``<code>``, 
+``<math>`` should also be ignored::
+
+    from typogrify.filters import typogrify
+    content = typogrify(content, "math")
+
+The argument can also be a list in order to specify multiple tags::
+
+    from typogrify.filters import typogrify
+    content = typogrify(content, ["math","script","mytag"])
+
 For use with Django, you can add ``typogrify`` to the ``INSTALLED_APPS`` setting
 of any Django project in which you wish to use it, and then use
 ``{% load typogrify_tags %}`` in your templates to load the filters it provides.


### PR DESCRIPTION
This functionality is needed for the Pelican blog project. Currently, Typogrify will clash with Latex math typesetting. This pull request gives Typogrify the ability to ignore certain things in the text by using a regular expression. If a regular expression is given as the second argument to Typogrify, then anything in the text that matches the regular expression will not be processed by Typogrify.

The main reason for doing this is due to Latex typesetting (Latex cannot have & altered to &amp - it will destroy the typesetting). But the pull request has been designed to be more general than this by using a regular expression.
