### PR TITLE
Fix bug that will ignore new lines

### DIFF
--- a/typogrify/filters.py
+++ b/typogrify/filters.py
@@ -27,7 +27,7 @@ def process_ignores(text, ignore_tags=None):
         ignore_re += "<"+tag+">.*?</"+tag+">|"
     ignore_re = ignore_re[:-1] # remove the last `|`
 
-    ignore_finder = re.compile(ignore_re, re.IGNORECASE)
+    ignore_finder = re.compile(ignore_re, re.IGNORECASE | re.DOTALL)
 
     raw_ignore = ignore_finder.finditer(text)
 


### PR DESCRIPTION
Hi Chris

This is quite a bug: We forgot to put the re.DOTALL flag in the regex. So newlines are ignored when interpreting .

That means our new functionality will work for this: <pre>Hello World</pre>
But it will not work for this:

<pre>
Hello
World
</pre>


I have updated the regex and things seem to work fine. Please can you confirm and publish if happy.
