### PR TITLE
improved regex, fixed bug, made tests

### DIFF
--- a/typogrify/filters.py
+++ b/typogrify/filters.py
@@ -29,7 +29,7 @@ def process_ignores(text, ignore_tags=None):
         ignore_tags = []
 
     ignore_tags = ignore_tags + ['pre', 'code']  # default tags
-    ignoreregex = r'<(%s)\s?.*?>.*?</(\1)>' % '|'.join(ignore_tags)
+    ignoreregex = r'<(%s).*?>.*?</(\1)>' % '|'.join(ignore_tags)
     ignore_finder = re.compile(ignoreregex, re.IGNORECASE | re.DOTALL)
 
     for section in ignore_finder.finditer(text):


### PR DESCRIPTION
Hi

As promised, this pull request provides the tests (via doctest) for ignoring specified tags (functionality provided in the process_ignores function).

In addition, this pull request does the following:
1. Vastly improves the regex for ignoring things: It is now more robust (it will ignore inline styles and ids provided in such tags - in fact, the ... will be ignored in the tag `<pre...>`, thereby matching things like `<pre id='test'>` etc
2. Fixed bug (although this bug was more of an annoyance than anything else). It was possible that the list that was returned by the function would have as a last item an empty string '' to ignore. A simple check fixes this.
3. Doctests are provided: Only three tests are given, but IMHO, it is enough.

The code also follows PEP 8, except for the doctstring which are longer than 79 characters. 
