### PR TITLE
repaired regular expression

### DIFF
--- a/typogrify/filters.py
+++ b/typogrify/filters.py
@@ -29,8 +29,8 @@ def process_ignores(text, ignore_tags=None):
         ignore_tags = []
 
     ignore_tags = ignore_tags + ['pre', 'code']  # default tags
-    ignoreregex = r'<(%s).*?>.*?</(\1)>' % '|'.join(ignore_tags)
-    ignore_finder = re.compile(ignoreregex, re.IGNORECASE | re.DOTALL)
+    ignore_regex = r'<(%s)(?:\s.*?)?>.*?</(\1)>' % '|'.join(ignore_tags)
+    ignore_finder = re.compile(ignore_regex, re.IGNORECASE | re.DOTALL)
 
     for section in ignore_finder.finditer(text):
         start, end = section.span()


### PR DESCRIPTION
It was pointed out to me that the regular expression had a slight error: It would incorrectly match prefixes, meaning that if I had a tag `<codetest>`, because it starts with `code`, it would get matched.

Instead, use a non-capturing group to force a whitespace first, because we want to match things of the form `<code test...>` not `<codetest>`

The submitted regular expressions fix this.
