### PR TITLE
Reformat the CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,19 +1,19 @@
 Changelog
 =========
 
-0.1.0 (2014-01-03)
+2.0.4 (2014-02-21)
 ------------------
 
-- add Python 3 compatibility
-- rectify deprecated function calls
-- packaging improvements, including binary wheels
+- moving titlecase into the project
 
 2.0.2 | 2.0.3
 -------------
 
 - adding support for custom ignore tags.
 
-2.0.4 (2014-02-21)
+0.1.0 (2014-01-03)
 ------------------
 
-- moving titlecase into the project
+- add Python 3 compatibility
+- rectify deprecated function calls
+- packaging improvements, including binary wheels


### PR DESCRIPTION
To keep an unified look.  And also to put new-on-top which is the world standard for those files.
