### PR TITLE
Fix widont newline behavior.

### DIFF
--- a/typogrify/filters.py
+++ b/typogrify/filters.py
@@ -11,8 +11,8 @@ def process_ignores(text, ignore_tags=None):
     can also be filtered on id and class using CSS notation.
     For example, div#test (div with id='test'), div.test
     (div with class='test'), #test (any tag with id='test')
-    or .test (any tag with class='test'). 
-    
+    or .test (any tag with class='test').
+
     Returns in the following format:
 
     [
@@ -54,9 +54,9 @@ def process_ignores(text, ignore_tags=None):
                  {attribute} \s*=\s*
                  (['"]) {attribute_value} \{0}
                  ))""".format(_filter_tag.group, **locals())
-       
+
         return result
-    
+
     _filter_tag.group = 1
     position = 0
     sections = []
@@ -281,7 +281,7 @@ def smartypants(text):
 
 
 def widont(text):
-    """Replaces the space between the last two words in a string with ``&nbsp;``
+    r"""Replaces the space between the last two words in a string with ``&nbsp;``
     Works in these block tags ``(h1-h6, p, li, dd, dt)`` and also accounts for
     potential closing inline elements ``a, em, strong, span, b, i``
 
@@ -319,11 +319,15 @@ def widont(text):
 
     >>> widont('<div><p>But divs with paragraphs do!</p></div>')
     '<div><p>But divs with paragraphs&nbsp;do!</p></div>'
+
+    Newlines shouldn't count as "the space to replace".
+    >>> widont('blah<br>\nblah')
+    'blah<br>\nblah'
     """
 
     widont_finder = re.compile(r"""((?:</?(?:a|em|span|strong|i|b)[^>]*>)|[^<>\s]) # must be proceeded by an approved inline opening or closing tag or a nontag/nonspace
-                                   \s+                                             # the space to replace
-                                   ([^<>\s]+                                       # must be flollowed by non-tag non-space characters
+                                   [^\S\n]                                         # the space to replace
+                                   ([^<>\s]+                                       # must be followed by non-tag non-space characters
                                    \s*                                             # optional white space!
                                    (</(a|em|span|strong|i|b)>\s*)*                 # optional closing inline tags with optional white space after each
                                    ((</(p|h[1-6]|li|dt|dd)>)|$))                   # end with a closing p, h1-6, li or the end of the string


### PR DESCRIPTION
Fix #38.

Widont shouldn't count newlines as spaces.  This is achieved with a regex inspired by [this SO post](http://stackoverflow.com/a/3992881/1938621). Rather than checking for a space (which includes newlines), we check for both (a) not not a space, and (b) not a newline.
