### PR TITLE
Add support for Jinja 3.1

### DIFF
--- a/typogrify/templatetags/jinja_filters.py
+++ b/typogrify/templatetags/jinja_filters.py
@@ -9,7 +9,10 @@ from typogrify.filters import (
     TypogrifyError,
 )
 from functools import wraps
-import jinja2
+try:
+    from markupsafe import Markup
+except ImportError:
+    from jinja2 import Markup
 from jinja2.exceptions import TemplateError
 
 
@@ -28,7 +31,7 @@ def make_safe(f):
             out = f(text)
         except TypogrifyError as e:
             raise TemplateError(e.message)
-        return jinja2.Markup(out)
+        return Markup(out)
 
     wrapper.is_safe = True
     return wrapper


### PR DESCRIPTION
Jinja 3.1.x has removed the jinja2.Markup function which was deprecated in Jinja 3.0.x which now causes the template functions in this package to break.

Added some fallback imports just to reduce the possibility of breakage with users running the latest version of typogrify and older versions of Flask/Jinja for whatever reason.

See:
- https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0
- https://github.com/pallets/jinja/pull/1544